### PR TITLE
[IMP] Alert user about song download error.

### DIFF
--- a/downloader.js
+++ b/downloader.js
@@ -66,6 +66,7 @@ var getURLArrayBuffer = function(url, onload) {
             onload(xhr.response);
         } else {
             console.error(xhr.statusText + ' (' + xhr.status + ')');
+            alert("Download error! \n This is because song may not available in selected bitrate!")
         }
     };
     xhr.onerror = function() {


### PR DESCRIPTION
When using this extension sometime its stuck at clock icon and user not able to know that song is downloading or not.
this is mainly because some songs not available in 320kbps and lowering bit-rate works.

instead of checking console log every time, alert box will alert user about something wrong with download.